### PR TITLE
Fix command to start service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM registry.opensource.zalan.do/stups/openjdk:latest
 COPY ./target/pazuzu-registry.jar /pazuzu-registry.jar
 COPY scm-source.json /
 EXPOSE 8080
-CMD java $JAVA_OPTS $(appdynamics-agent) $(java-dynamic-memory-opts) /pazuzu-registry.jar
+CMD java $JAVA_OPTS $(appdynamics-agent) $(java-dynamic-memory-opts) -jar /pazuzu-registry.jar


### PR DESCRIPTION
Looks like there was a mistake when `appdynamics-agent` and
`java-dynamic-memory-opts` were introduced inside `Dockerfile`, because
we have to specify `-jar` option. Otherwise image would not be started.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zalando-incubator/pazuzu-registry/165)
<!-- Reviewable:end -->
